### PR TITLE
PT-166788647 FATE efficient maps

### DIFF
--- a/include/aeb_fate_data.hrl
+++ b/include/aeb_fate_data.hrl
@@ -5,6 +5,7 @@
 -define(FATE_LIST_T,      list()).
 -define(FATE_UNIT_T,      {tuple, {}}).
 -define(FATE_MAP_T,       #{ fate_type() => fate_type() }).
+-define(FATE_STORE_MAP_T, {store_map, #{ fate_type() => fate_type() | ?FATE_MAP_TOMBSTONE }, integer()}).
 -define(FATE_STRING_T,    binary()).
 -define(FATE_ADDRESS_T,   {address, <<_:256>>}).
 -define(FATE_BYTES_T(N),  {bytes, binary()}).
@@ -20,6 +21,10 @@
 -define(IS_FATE_INTEGER(X), (is_integer(X))).
 -define(IS_FATE_LIST(X),    (is_list(X))).
 -define(IS_FATE_STRING(X),  (is_binary(X))).
+-define(IS_FATE_STORE_MAP(X), (is_tuple(X) andalso tuple_size(X) == 3
+                                           andalso store_map == element(1, X)
+                                           andalso is_map(element(2, X))
+                                           andalso is_integer(element(3, X)))).
 -define(IS_FATE_MAP(X),     (is_map(X))).
 -define(IS_FATE_TUPLE(X),   (is_tuple(X) andalso (tuple == element(1, X) andalso is_tuple(element(2, X))))).
 -define(IS_FATE_ADDRESS(X), (is_tuple(X) andalso (address == element(1, X) andalso is_binary(element(2, X))))).
@@ -50,6 +55,8 @@
 -define(FATE_CHANNEL(X),   {channel, X}).
 -define(FATE_BITS(B),      {bits, B}).
 -define(FATE_TYPEREP(T),   {typerep, T}).
+-define(FATE_STORE_MAP(Cache, Id), {store_map, Cache, Id}).
+-define(FATE_MAP_TOMBSTONE, '__DELETED__').
 
 -define(FATE_INTEGER_VALUE(X), (X)).
 -define(FATE_BOOLEAN_VALUE(X), (X)).
@@ -63,6 +70,8 @@
 -define(FATE_CHANNEL_VALUE(X), (element(2, X))).
 -define(FATE_BITS_VALUE(X), (element(2, X))).
 -define(FATE_MAP_VALUE(X), (X)).
+-define(FATE_STORE_MAP_CACHE(X), (element(2, X))).
+-define(FATE_STORE_MAP_ID(X), (element(3, X))).
 -define(FATE_MAP_SIZE(X), (map_size(X))).
 -define(FATE_STRING_SIZE(X), (byte_size(X))).
 -define(FATE_TRUE,  true).

--- a/src/aeb_fate_data.erl
+++ b/src/aeb_fate_data.erl
@@ -10,6 +10,7 @@
 -type fate_list()      :: ?FATE_LIST_T.
 -type fate_unit()      :: ?FATE_UNIT_T.
 -type fate_map()       :: ?FATE_MAP_T.
+-type fate_store_map() :: ?FATE_STORE_MAP_T.
 -type fate_string()    :: ?FATE_STRING_T.
 -type fate_address()   :: ?FATE_ADDRESS_T.
 -type fate_hash()      :: ?FATE_BYTES_T(32).
@@ -71,6 +72,7 @@
              , fate_channel/0
              , fate_variant/0
              , fate_map/0
+             , fate_store_map/0
              , fate_bits/0
              , fate_type_type/0
              ]).
@@ -82,6 +84,8 @@
         , make_tuple/1
         , make_string/1
         , make_map/1
+        , make_store_map/1
+        , make_store_map/2
         , make_address/1
         , make_bytes/1
         , make_hash/1
@@ -108,6 +112,8 @@ make_list(L) ->        ?MAKE_FATE_LIST(L).
 make_unit() ->         ?FATE_UNIT.
 make_tuple(T) ->       ?FATE_TUPLE(T).
 make_map(M) ->         ?MAKE_FATE_MAP(M).
+make_store_map(Id) ->  make_store_map(#{}, Id).
+make_store_map(Cache, Id) -> ?FATE_STORE_MAP(Cache, Id).
 make_address(X) ->     ?FATE_ADDRESS(X).
 make_bytes(X) ->       ?FATE_BYTES(X).
 make_hash(X) ->        make_bytes(X).

--- a/src/aeb_fate_generate_ops.erl
+++ b/src/aeb_fate_generate_ops.erl
@@ -48,9 +48,9 @@ ops_defs() ->
     , { 'CALL',                16#02,   true,    true,   true,  4, [a],                call,                             {string},     any, "Call the function Arg0 with args on stack. The types of the arguments has to match the argument typs of the function."}
     , { 'CALL_R',              16#03,   true,   false,   true,  8, [a,is,ii,a],      call_r, {contract, string, integer, integer},     any, "Remote call to contract Arg0 and Arg2-ary function Arg1 with value Arg3. The types of the arguments has to match the argument typs of the function."}
     , { 'CALL_T',              16#04,   true,    true,   true,  4, [a],              call_t,                             {string},     any, "Tail call to function Arg0. The types of the arguments has to match the argument typs of the function. And the return type of the called function has to match the type of the current function."}
-    , { 'CALL_TR',             16#05,   true,   false,   true,  8, [a,is,a],        call_tr,          {contract, string, integer},     any, "DEPRECATED: Remote tail call to contract Arg0 and function Arg1 with value Arg2. The types of the arguments has to match the argument typs of the function. And the return type of the called function has to match the type of the current function."}
+    , { 'UNUSED_1',            16#05,  false,   false,   true,  8, [],             unused_1,                                   {},    none, "Was CALL_TR."}
     , { 'CALL_GR',             16#06,   true,   false,   true,  8, [a,is,ii,a,a],   call_gr, {contract, string, integer, integer, integer}, any, "Remote call with gas cap in Arg3. Otherwise as CALL_R."}
-    , { 'CALL_GTR',            16#07,   true,   false,   true,  8, [a,is,a,a],     call_gtr, {contract, string, integer, integer},     any, "DEPRECATED: Remote tail call with gas cap in Arg3. Otherwise as CALL_TR."}
+    , { 'UNUSED_2',            16#07,  false,   false,   true,  8, [],             unused_2,                                   {},    none, "Was CALL_GTR."}
     , { 'JUMP',                16#08,   true,    true,   true,  3, [ii],               jump,                            {integer},    none, "Jump to a basic block. The basic block has to exist in the current function."}
     , { 'JUMPIF',              16#09,   true,    true,   true,  4, [a,ii],           jumpif,                   {boolean, integer},    none, "Conditional jump to a basic block. If Arg0 then jump to Arg1."}
     , { 'SWITCH_V2',           16#0a,   true,    true,   true,  4, [a,ii,ii],        switch,          {variant, integer, ingeger},    none, "Conditional jump to a basic block on variant tag."}
@@ -501,14 +501,16 @@ gen_format(#{opname := Name}) when (Name =:= 'CALL_R') ->
                   "format_arg(a, Value)];\n",
                   [Name, atom_to_list(Name), Name, atom_to_list(Name)]);
 gen_format(#{opname := Name}) when (Name =:= 'CALL_GR') ->
-    io_lib:format("format_op({~w, {immediate, Contract}, {immediate, Function}, {immediate, Arity}, Value, Gas}, Symbols) ->\n"
+    io_lib:format("format_op({~w, {immediate, Contract}, {immediate, Function}, Arity, Value, Gas}, Symbols) ->\n"
                   "    [\"~s \", lookup(Contract, Symbols), \".\", "
                   "lookup(Function, Symbols), \" \", "
+                  "format_arg(a, Arity),  \" \", "
                   "format_arg(a, Value),  \" \", "
                   "format_arg(a, Gas)];\n"
-                  "format_op({~w, Contract, {immediate, Function}, {immediate, Arity}, Value, Gas}, Symbols) ->\n"
+                  "format_op({~w, Contract, {immediate, Function}, Arity, Value, Gas}, Symbols) ->\n"
                   "[\"~s \", format_arg(a, Contract), \".\", "
                   "lookup(Function, Symbols), \" \", "
+                  "format_arg(a, Arity),  \" \", "
                   "format_arg(a, Value),  \" \", "
                   "format_arg(a, Gas)];\n",
                   [Name, atom_to_list(Name), Name, atom_to_list(Name)]);

--- a/src/aeb_fate_maps.erl
+++ b/src/aeb_fate_maps.erl
@@ -1,0 +1,96 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2019, Aeternity Anstalt
+%%% @doc
+%%%     Functions for manipulating FATE maps. In particular for mediating
+%%%     between plain map values (represented by Erlang maps) and maps that are
+%%%     fully or partially saved in the contract store.
+%%%  @end
+%%%    -------------------------------------------------------------------
+-module(aeb_fate_maps).
+
+-include("aeb_fate_data.hrl").
+
+-export([allocate_store_maps/2, no_used_ids/0]).
+
+-export_type([used_ids/0, maps/0]).
+
+%% Size in bytes of serialization of a map for which we turn it into a store
+%% map. It's not worth turning small maps into store maps.
+%% Under consensus!
+-define(STORE_MAP_THRESHOLD, 500).
+
+-type fate_value() :: aeb_fate_data:fate_type().
+-type id() :: integer().
+-type used_ids() :: list(id()).    %% TODO: more clever representation
+-type maps() :: #{ id() => aeb_fate_data:fate_map() | aeb_fate_data:fate_store_map() }.
+
+-spec allocate_store_maps(used_ids(), [fate_value()]) ->
+        {[fate_value()], maps()}.
+allocate_store_maps(Used, Vals) ->
+    allocate_store_maps_l(Used, Vals, #{}).
+
+allocate_store_maps(Used, ?FATE_MAP_TOMBSTONE = Val, Maps) -> {Used, Val, Maps};
+allocate_store_maps(Used, ?FATE_TRUE          = Val, Maps) -> {Used, Val, Maps};
+allocate_store_maps(Used, ?FATE_FALSE         = Val, Maps) -> {Used, Val, Maps};
+allocate_store_maps(Used, ?FATE_UNIT          = Val, Maps) -> {Used, Val, Maps};
+allocate_store_maps(Used, ?FATE_BITS(_)       = Val, Maps) -> {Used, Val, Maps};
+allocate_store_maps(Used, ?FATE_BYTES(_)      = Val, Maps) -> {Used, Val, Maps};
+allocate_store_maps(Used, ?FATE_ADDRESS(_)    = Val, Maps) -> {Used, Val, Maps};
+allocate_store_maps(Used, ?FATE_CONTRACT(_)   = Val, Maps) -> {Used, Val, Maps};
+allocate_store_maps(Used, ?FATE_ORACLE(_)     = Val, Maps) -> {Used, Val, Maps};
+allocate_store_maps(Used, ?FATE_ORACLE_Q(_)   = Val, Maps) -> {Used, Val, Maps};
+allocate_store_maps(Used, ?FATE_CHANNEL(_)    = Val, Maps) -> {Used, Val, Maps};
+allocate_store_maps(Used, ?FATE_TYPEREP(_)    = Val, Maps) -> {Used, Val, Maps};
+allocate_store_maps(Used, Val, Maps) when ?IS_FATE_INTEGER(Val) -> {Used, Val, Maps};
+allocate_store_maps(Used, Val, Maps) when ?IS_FATE_STRING(Val)  -> {Used, Val, Maps};
+allocate_store_maps(Used, ?FATE_TUPLE(Val), Maps) ->
+    {Used1, Vals, Maps1} = allocate_store_maps_l(Used, tuple_to_list(Val), Maps),
+    {Used1, ?FATE_TUPLE(list_to_tuple(Vals)), Maps1};
+allocate_store_maps(Used, Val, Maps) when ?IS_FATE_LIST(Val) ->
+    {Used1, Vals, Maps1} = allocate_store_maps_l(Used, ?FATE_LIST_VALUE(Val), Maps),
+    {Used1, ?MAKE_FATE_LIST(Vals), Maps1};
+allocate_store_maps(Used, ?FATE_VARIANT(Arities, Tag, Vals), Maps) ->
+    {Used1, Vals1, Maps1} = allocate_store_maps_l(Used, tuple_to_list(Vals), Maps),
+    {Used1, ?FATE_VARIANT(Arities, Tag, list_to_tuple(Vals1)), Maps1};
+allocate_store_maps(Used, Val, Maps) when ?IS_FATE_MAP(Val) ->
+    {Used1, KVs, Maps1} = allocate_store_maps_m(Used, ?FATE_MAP_VALUE(Val), Maps),
+    Val1 = ?MAKE_FATE_MAP(KVs),
+    case byte_size(aeb_fate_encoding:serialize(Val1)) < ?STORE_MAP_THRESHOLD of
+        true -> {Used1, Val1, Maps1};
+        false ->
+            {Id, Used2} = next_id(Used1),
+            {Used2, ?FATE_STORE_MAP(#{}, Id), Maps1#{Id => Val1}}
+    end;
+allocate_store_maps(Used, ?FATE_STORE_MAP(Cache, _Id) = Val, Maps) when Cache =:= #{} ->
+    {Used, Val, Maps};
+allocate_store_maps(Used, ?FATE_STORE_MAP(Cache, Id), Maps) ->
+    {NewId, Used1} = next_id(Used),
+    {Used1, Cache1, Maps1} = allocate_store_maps_m(Used1, Cache, Maps),
+    {Used1, ?FATE_STORE_MAP(#{}, NewId), Maps1#{NewId => ?FATE_STORE_MAP(Cache1, Id)}}.
+
+allocate_store_maps_l(Used, [], Maps) -> {Used, [], Maps};
+allocate_store_maps_l(Used, [H | T], Maps) ->
+    {Used1, H1, Maps1} = allocate_store_maps(Used, H, Maps),
+    {Used2, T1, Maps2} = allocate_store_maps(Used1, T, Maps1),
+    {Used2, [H1 | T1], Maps2}.
+
+allocate_store_maps_m(Used, Val, Maps) ->
+    KVs = [ ?FATE_TUPLE(KV) || KV <- maps:to_list(Val) ],
+    {Used1, KVs1, Maps1} = allocate_store_maps_l(Used, KVs, Maps),
+    {Used1, maps:from_list([ KV || ?FATE_TUPLE(KV) <- KVs1 ]), Maps1}.
+
+%% -- Map id allocation ------------------------------------------------------
+
+-spec no_used_ids() -> used_ids().
+no_used_ids() -> [].
+
+-spec next_id(used_ids()) -> {id(), used_ids()}.
+next_id(UsedIds) ->
+    next_id(UsedIds, 0, []).
+
+next_id(Used, J, Acc) when Used == []; J < hd(Used) ->
+    {J, lists:reverse(Acc) ++ [J | Used]};
+next_id([I | Used], I, Acc) ->
+    next_id(Used, I + 1, [I | Acc]);
+next_id([I | Used], J, Acc) when J > I ->
+    next_id(Used, J, [I | Acc]).

--- a/src/aeb_fate_maps.erl
+++ b/src/aeb_fate_maps.erl
@@ -20,7 +20,7 @@
         , refcount_union/2
         , no_used_ids/0 ]).
 
--export_type([used_ids/0, maps/0]).
+-export_type([used_ids/0, maps/0, refcount/0]).
 
 %% Size in bytes of serialization of a map for which we turn it into a store
 %% map. It's not worth turning small maps into store maps.

--- a/src/aeb_fate_maps.erl
+++ b/src/aeb_fate_maps.erl
@@ -159,7 +159,7 @@ has_store_maps(Val) ->
 -spec refcount(fate_value()) -> refcount().
 refcount(Val) -> refcount(Val, #{}).
 
--spec refcount(refcount(), fate_value()) -> refcount().
+-spec refcount(fate_value(), refcount()) -> refcount().
 refcount(?FATE_MAP_TOMBSTONE, Count) -> Count;
 refcount(?FATE_TRUE,          Count) -> Count;
 refcount(?FATE_FALSE,         Count) -> Count;

--- a/test/asm_code/test.fate
+++ b/test/asm_code/test.fate
@@ -30,13 +30,9 @@ FUNCTION tailcall(integer) -> integer
 
 FUNCTION remote_call(integer) : integer
   PUSH arg0
-  CALL_R remote.add_five 0
+  CALL_R remote.add_five 1 0
   INCA
   RETURN
-
-FUNCTION remote_tailcall(integer) : integer
-  PUSH  arg0
-  CALL_TR remote add_five 0
 
 ;; Test the code from the shell
 ;; _build/default/rel/aessembler/bin/aessembler console


### PR DESCRIPTION
- [PT-166788647](https://www.pivotaltracker.com/story/show/166788647)
- aeternity/aesophia#121
-  aeternity/aeternity#2646

Adds support for efficient maps in the contract state. This adds a new FATE value `?FATE_STORE_MAP(Cache, Id)` containing a reference to a map saved in the state and a cache of updates to it. When writing the state we go over the terms and allocate store maps for (sufficiently large) maps and updates to old maps. See `aeb_fate_maps:allocate_store_maps/2`. Also some code for doing reference counting to enable garbage collection. The bulk of that code is in the aeternity PR.

Other minor things
- Removes remote tail call instructions
- Adds an arity argument to remote calls. Previously remote calls with wrong arity could mess up the stack, now they fail with a nice error.