### PR TITLE
Avoid unnecessery calls to eblake2

### DIFF
--- a/include/aeb_fate_data.hrl
+++ b/include/aeb_fate_data.hrl
@@ -82,6 +82,9 @@
 -define(FATE_EMPTY_STRING, <<>>).
 -define(FATE_STRING(S), S).
 -define(FATE_VARIANT(Arity, Tag,T), {variant, Arity, Tag, T}).
+% Result of aeb_fate_code:symbol_identifier(<<"init">>).
+% Stored here to avoid repeated calls to eblake2
+-define(FATE_INIT_ID, <<68,214,68,31>>).
 
 -define(MAKE_FATE_INTEGER(X), X).
 -define(MAKE_FATE_LIST(X), X).

--- a/src/aeb_fate_code.erl
+++ b/src/aeb_fate_code.erl
@@ -95,9 +95,8 @@ insert_annotation(comment =_Type, Line, Comment, FCode) ->
 
 strip_init_function(#fcode{ functions = Funs,
                             symbols   = Syms } = FCode) ->
-    Id    = symbol_identifier(<<"init">>),
-    Funs1 = maps:remove(Id, Funs),
-    Syms1 = maps:remove(Id, Syms),
+    Funs1 = maps:remove(?FATE_INIT_ID, Funs),
+    Syms1 = maps:remove(?FATE_INIT_ID, Syms),
     FCode#fcode{ functions = Funs1, symbols = Syms1 }.
 
 %%%===================================================================


### PR DESCRIPTION
We frequently need identifier of init function. Store it precalculated in headers.